### PR TITLE
emscripten のビルドオプションから `ALLOW_MEMORY_GROWTH` を外して `INITIAL_MEMORY=64MB` を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
     - バグ修正
 
 ## develop
+- [CHANGE] emscripten のビルドオプションから `ALLOW_MEMORY_GROWTH` を外して `INITIAL_MEMORY=64MB` を追加
+  - モバイル Safari では `ALLOW_MEMORY_GROWTH` オプション付きでビルドされた wasm ファイルはエラーになるため
+  - @sile
 - [UPDATE] google/lyra のバージョンを 1.3.2 に更新
   - @sile
 

--- a/wasm/BUILD
+++ b/wasm/BUILD
@@ -11,7 +11,7 @@ cc_binary(
     linkopts = [
       "--bind",
       "--use-preload-plugins",
-      "-s ALLOW_MEMORY_GROWTH",
+      "-s INITIAL_MEMORY=64MB",
       "-s EXPORT_ES6=1",
       "-s MODULARIZE=1",
       "-s EXPORT_NAME=LyraWasmModule",


### PR DESCRIPTION
モバイル Safari では `ALLOW_MEMORY_GROWTH` オプション付きでビルドされた wasm ファイルはエラーになるため。

Lyra の encoder / decoder は一つのインスタンス辺り、おおむね 5MB のメモリを消費するので `INITIAL_MEMORY=64MB` なら 12 個のインスタンスが作れることになる。
また encoder / decoder は生成時のパラメータ（e.g., sample_rate）が同じであれば使い回しが可能なはずなので、これらのインスタンスをプールすることで、以下のように 12 インスタンスがあればユニークなパラメータの組み合わせはカバーできることになる。
- decoder: 4 (sample_rate=8000 | 16000 | 32000 | 48000)
- encoder: 4 (sample_rate=8000 | 16000 | 32000 | 48000) * 2 (dtx=true|false) 
  - 4 + 4 * 2 = 12
  - ※ encoder には三種類のビットレートを指定できるが、途中で変更が可能なのでインスタンスは使いまわせる
  - ※ sample_rate は四種類あるが、内部的には 16000 にリサンプリングされるので、それを利用側で行えばさらに 1/4 にユニークなインスタンス数は減らせる

インスタンスのプールは現在進行中の web worker 対応の中で行う予定。

おそらく大丈夫だとは思うが、もし固定メモリでは扱えないケースが現実に出てきた場合には、`ALLOW_MEMORY_GROWTH` オプション付きでビルドした wasm バイナリを別途提供することを検討する。