### PR TITLE
FS_createPreloadedFile() の代わりに FS_createDataFile() を使用する

### DIFF
--- a/src/lyra_wasm.d.ts
+++ b/src/lyra_wasm.d.ts
@@ -31,7 +31,14 @@ export interface LyraWasmModule extends EmscriptenModule {
   newAudioData(numberOfSamples: number): AudioData;
   copyAudioDataToInt16Array(to: Int16Array, from: AudioData): void;
   copyInt16ArrayToAudioData(to: AudioData, from: Int16Array): void;
-  FS_createPreloadedFile(parent: string, name: string, url: string, canRead: boolean, canWrite: boolean): void;
+  FS_createDataFile(
+    parent: string,
+    name: string,
+    data: Uint8Array,
+    canRead: boolean,
+    canWrite: boolean,
+    canOwn: boolean
+  ): any;
 }
 
 export interface LoadLyraWasmModuleOptions {

--- a/wasm/BUILD
+++ b/wasm/BUILD
@@ -10,11 +10,11 @@ cc_binary(
     ],
     linkopts = [
       "--bind",
-      "--use-preload-plugins",
       "-s INITIAL_MEMORY=64MB",
       "-s EXPORT_ES6=1",
       "-s MODULARIZE=1",
       "-s EXPORT_NAME=LyraWasmModule",
+      "-s FORCE_FILESYSTEM",
 
       # [FIXME]
       # "undefined symbol: _Unwind_GetIP (referenced by top-level compiled C/C++ code)" エラーを抑制するためのオプション


### PR DESCRIPTION
#14 のフォローアップ PR 。

今まではモデルファイルを wasm 内から参照できるようにするために `FS_createPreloadedFile()` を使っていたが、 web worker 化に伴い以下の問題が生じるようになった:
- worker 作成時に`Browser does not support creating object URLs. Built-in browser image decoding will not be available.` という警告が出る
- `FS_createPreloadedFile()` は wasm の `preRun()` フックで呼び出す必要があるが、ここで失敗しても worker の起動側にはエラー（例外）が伝達しない（起動側は promise の完了を延々と待つ状態になってしまう）

モデルファイルを通常の Fetch API を使って取得し、それを `FS_createDataFile()` を使って wasm 内のファイルシステムに配置するようにすれば、上の二つの問題は解決するので、この PR ではそれを行なっている。