### PR TITLE
web worker 内の decoder / encoder インスタンスは共有しないようにする

### DIFF
--- a/src/lyra_sync_worker.ts
+++ b/src/lyra_sync_worker.ts
@@ -1,62 +1,99 @@
 import { LyraSyncDecoder, LyraSyncEncoder, LyraEncoderOptions, LyraSyncModule } from "./lyra_sync";
-import { DEFAULT_CHANNELS, DEFAULT_ENABLE_DTX, DEFAULT_SAMPLE_RATE, LyraDecoderOptions } from "./utils";
+import { LyraDecoderOptions } from "./utils";
 
-let LYRA_MODULE: LyraSyncModule | undefined;
-const LYRA_ENCODER_POOL: Map<string, WeakRef<LyraSyncEncoder>> = new Map();
-const LYRA_DECODER_POOL: Map<string, WeakRef<LyraSyncDecoder>> = new Map();
+// エンコーダとデコーダのインスタンスの合計数の最大値
+//
+// この値を変更する場合には wasm/BUILD にある `-s INITIAL_MEMORY` の値も合わせて変更すること
+const MAX_RESOURCES = 10;
 
-function encoderPoolKey(options: LyraEncoderOptions): string {
-  // NOTE: ビットレートは動的に変更可能なのでキーには含めない
-  const sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
-  const numberOfChannels = options.numberOfChannels || DEFAULT_CHANNELS;
-  const enableDtx = options.enableDtx || DEFAULT_ENABLE_DTX;
-  return `${sampleRate}:${numberOfChannels}:${enableDtx ? 1 : 0}`;
-}
+let RESOURCE_MANAGER: ResourceManager | undefined;
 
-function decoderPoolKey(options: LyraDecoderOptions): string {
-  const sampleRate = options.sampleRate || DEFAULT_SAMPLE_RATE;
-  const numberOfChannels = options.numberOfChannels || DEFAULT_CHANNELS;
-  return `${sampleRate}:${numberOfChannels}`;
-}
+class ResourceManager {
+  lyraModule: LyraSyncModule;
+  encoders: Map<MessagePort, Resource<LyraSyncEncoder>> = new Map();
+  decoders: Map<MessagePort, Resource<LyraSyncDecoder>> = new Map();
 
-async function loadLyraModule(wasmPath: string, modelPath: string): Promise<void> {
-  LYRA_MODULE = await LyraSyncModule.load(wasmPath, modelPath);
-}
-
-function createLyraEncoder(options: LyraEncoderOptions): LyraSyncEncoder {
-  if (LYRA_MODULE === undefined) {
-    throw new Error("LYRA_MODULE is undefined");
+  constructor(lyraModule: LyraSyncModule) {
+    this.lyraModule = lyraModule;
   }
 
-  const key = encoderPoolKey(options);
-
-  const weakEncoder = LYRA_ENCODER_POOL.get(key);
-  let encoder = weakEncoder && weakEncoder.deref();
-  if (encoder !== undefined) {
+  createEncoder(port: MessagePort, options: LyraEncoderOptions): LyraSyncEncoder {
+    this.evictIfNeed();
+    const encoder = this.lyraModule.createEncoder(options);
+    this.encoders.set(port, new Resource(encoder));
     return encoder;
   }
 
-  encoder = LYRA_MODULE.createEncoder(options);
-  LYRA_ENCODER_POOL.set(key, new WeakRef(encoder));
-  return encoder;
-}
-
-function createLyraDecoder(options: LyraDecoderOptions): LyraSyncDecoder {
-  if (LYRA_MODULE === undefined) {
-    throw new Error("LYRA_MODULE is undefined");
-  }
-
-  const key = decoderPoolKey(options);
-
-  const weakDecoder = LYRA_DECODER_POOL.get(key);
-  let decoder = weakDecoder && weakDecoder.deref();
-  if (decoder !== undefined) {
+  createDecoder(port: MessagePort, options: LyraDecoderOptions): LyraSyncDecoder {
+    this.evictIfNeed();
+    const decoder = this.lyraModule.createDecoder(options);
+    this.decoders.set(port, new Resource(decoder));
     return decoder;
   }
 
-  decoder = LYRA_MODULE.createDecoder(options);
-  LYRA_DECODER_POOL.set(key, new WeakRef(decoder));
-  return decoder;
+  getEncoder(port: MessagePort, options: LyraEncoderOptions): LyraSyncEncoder {
+    const encoder = this.encoders.get(port);
+    if (encoder !== undefined) {
+      encoder.lastAccessedTime = performance.now();
+      return encoder.item;
+    } else {
+      return this.createEncoder(port, options);
+    }
+  }
+
+  getDecoder(port: MessagePort, options: LyraDecoderOptions): LyraSyncDecoder {
+    const decoder = this.decoders.get(port);
+    if (decoder !== undefined) {
+      decoder.lastAccessedTime = performance.now();
+      return decoder.item;
+    } else {
+      return this.createDecoder(port, options);
+    }
+  }
+
+  remove(port: MessagePort): void {
+    this.encoders.delete(port);
+    this.decoders.delete(port);
+  }
+
+  evictIfNeed(): void {
+    if (this.encoders.size + this.decoders.size < MAX_RESOURCES) {
+      return;
+    }
+
+    // インスタンス数の上限に達している場合には、使用された時刻が一番古いものを削除する
+    let oldestPort;
+    let oldestTime;
+    for (const [port, resource] of this.encoders.entries()) {
+      if (oldestTime === undefined || resource.lastAccessedTime < oldestTime) {
+        oldestPort = port;
+        oldestTime = resource.lastAccessedTime;
+      }
+    }
+    for (const [port, resource] of this.decoders.entries()) {
+      if (oldestTime === undefined || resource.lastAccessedTime < oldestTime) {
+        oldestPort = port;
+        oldestTime = resource.lastAccessedTime;
+      }
+    }
+    if (oldestPort !== undefined) {
+      this.remove(oldestPort);
+    }
+  }
+}
+
+class Resource<T> {
+  item: T;
+  lastAccessedTime: number;
+
+  constructor(item: T) {
+    this.item = item;
+    this.lastAccessedTime = performance.now();
+  }
+}
+
+async function initResourceManager(wasmPath: string, modelPath: string): Promise<void> {
+  RESOURCE_MANAGER = new ResourceManager(await LyraSyncModule.load(wasmPath, modelPath));
 }
 
 type ModuleMessage = { data: ModuleMessageData };
@@ -70,7 +107,7 @@ self.onmessage = async function handleModuleMessage(msg: ModuleMessage) {
   switch (msg.data.type) {
     case "LyraModule.load":
       try {
-        await loadLyraModule(msg.data.wasmPath, msg.data.modelPath);
+        await initResourceManager(msg.data.wasmPath, msg.data.modelPath);
         self.postMessage({ type: `${msg.data.type}.result`, result: {} });
       } catch (error) {
         self.postMessage({ type: `${msg.data.type}.result`, result: { error } });
@@ -80,9 +117,14 @@ self.onmessage = async function handleModuleMessage(msg: ModuleMessage) {
       {
         const port = msg.data.port;
         try {
-          const encoder = createLyraEncoder(msg.data.options);
+          const manager = RESOURCE_MANAGER;
+          if (manager === undefined) {
+            throw new Error("RESOURCE_MANAGER is undefined");
+          }
+          const options = msg.data.options;
+          const encoder = manager.createEncoder(port, options);
           port.onmessage = (msg) => {
-            handleEncoderMessage(port, encoder, msg);
+            handleEncoderMessage(manager, port, options, msg);
           };
           port.postMessage({ type: `${msg.data.type}.result`, result: { frameSize: encoder.frameSize } });
         } catch (error) {
@@ -94,9 +136,14 @@ self.onmessage = async function handleModuleMessage(msg: ModuleMessage) {
       {
         const port = msg.data.port;
         try {
-          const decoder = createLyraDecoder(msg.data.options);
+          const manager = RESOURCE_MANAGER;
+          if (manager === undefined) {
+            throw new Error("RESOURCE_MANAGER is undefined");
+          }
+          const options = msg.data.options;
+          const decoder = manager.createDecoder(port, options);
           port.onmessage = (msg) => {
-            handleDecoderMessage(port, decoder, msg);
+            handleDecoderMessage(manager, port, options, msg);
           };
           port.postMessage({ type: `${msg.data.type}.result`, result: { frameSize: decoder.frameSize } });
         } catch (error) {
@@ -116,11 +163,16 @@ type EncoderMessageData =
   | { type: "LyraEncoder.encode"; audioData: Int16Array; bitrate: 3200 | 6000 | 9200 }
   | { type: "LyraEncoder.destroy" };
 
-function handleEncoderMessage(port: MessagePort, encoder: LyraSyncEncoder, msg: EncoderMessage): void {
+function handleEncoderMessage(
+  manager: ResourceManager,
+  port: MessagePort,
+  options: LyraEncoderOptions,
+  msg: EncoderMessage
+): void {
   switch (msg.data.type) {
     case "LyraEncoder.encode":
       try {
-        encoder.setBitrate(msg.data.bitrate);
+        const encoder = manager.getEncoder(port, options);
         const encodedAudioData = encoder.encode(msg.data.audioData);
         const response = { type: `${msg.data.type}.result`, result: { encodedAudioData } };
         if (encodedAudioData === undefined) {
@@ -133,6 +185,7 @@ function handleEncoderMessage(port: MessagePort, encoder: LyraSyncEncoder, msg: 
       }
       break;
     case "LyraEncoder.destroy":
+      manager.remove(port);
       port.onmessage = null;
       break;
     default:
@@ -147,10 +200,16 @@ type DecoderMessageData =
   | { type: "LyraDecoder.decode"; encodedAudioData: Uint8Array | undefined }
   | { type: "LyraDecoder.destroy" };
 
-function handleDecoderMessage(port: MessagePort, decoder: LyraSyncDecoder, msg: DecoderMessage): void {
+function handleDecoderMessage(
+  manager: ResourceManager,
+  port: MessagePort,
+  options: LyraDecoderOptions,
+  msg: DecoderMessage
+): void {
   switch (msg.data.type) {
     case "LyraDecoder.decode":
       try {
+        const decoder = manager.getDecoder(port, options);
         const audioData = decoder.decode(msg.data.encodedAudioData);
         port.postMessage({ type: `${msg.data.type}.result`, result: { audioData } }, [audioData.buffer]);
       } catch (error) {
@@ -158,6 +217,7 @@ function handleDecoderMessage(port: MessagePort, decoder: LyraSyncDecoder, msg: 
       }
       break;
     case "LyraDecoder.destroy":
+      manager.remove(port);
       port.onmessage = null;
       break;
     default:

--- a/src/lyra_sync_worker.ts
+++ b/src/lyra_sync_worker.ts
@@ -52,8 +52,20 @@ class ResourceManager {
   }
 
   remove(port: MessagePort): void {
-    this.encoders.delete(port);
-    this.decoders.delete(port);
+    {
+      const resource = this.encoders.get(port);
+      if (resource !== undefined) {
+        resource.item.destroy();
+        this.encoders.delete(port);
+      }
+    }
+    {
+      const resource = this.decoders.get(port);
+      if (resource !== undefined) {
+        resource.item.destroy();
+        this.decoders.delete(port);
+      }
+    }
   }
 
   evictIfNeed(): void {


### PR DESCRIPTION
#14 のフォローアップ PR。
今まではエンコードおよびデコードパラメータが同じインスタンスを共有して使い回していたが、これだとデコード後の音声に問題が生じる（フレーム境界でぶつぶつ音が混じる）ことが分かったので修正する。

インスタンス共有の代わりに `ResourceManager` クラスを導入して、エンコーダおよびデコーダインスタンスの合計数の最大値を管理するようにした。
最大値を超えた場合には、一番最後に使用されたインスタンスが破棄される。破棄されたインスタンスが再度必要になった場合には、そのタイミングでまた同じパラメータを使ってインスタンスが再生成されることになる。
最悪ケースは、上限（10 個）を超えたインスタンスが常時同時に使用されるケースで、その場合にはフレーム境界のぶつぶつ音が発生する可能性があるが「10 人以上が同時に発言し続ける」といったようなシチュエーションでもなければ生じない問題なので、実用上は問題ないものと思われる。